### PR TITLE
update javascript/rest-nextjs example to use crdb

### DIFF
--- a/javascript/rest-nextjs/README.md
+++ b/javascript/rest-nextjs/README.md
@@ -2,6 +2,9 @@
 
 This example shows how to implement a **fullstack app with [Next.js](https://nextjs.org/)** using [React](https://reactjs.org/) (frontend), [Express](https://expressjs.com/) and [Prisma Client](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client) (backend). It uses a SQLite database file with some initial dummy data which you can find at [`./prisma/dev.db`](./prisma/dev.db).
 
+## Install on Vercel with Cockroach DB in 1-click
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fcockroachdb%2Fprisma-examples%2Ftree%2Flatest%2Fjavascript%2Frest-nextjs&integration-ids=oac_h3yNIuHlhe4j9QVzVJ3TS2W0&build-command=yarn%20prisma%20db%20push%20%26%26%20yarn%20next%20build)
+
 ## Getting started
 
 ### 1. Download example and install dependencies

--- a/javascript/rest-nextjs/pages/api/post/[id].js
+++ b/javascript/rest-nextjs/pages/api/post/[id].js
@@ -15,7 +15,7 @@ export default async function handle(req, res) {
 // DELETE /api/post/:id
 async function handleDELETE(postId, res) {
   const post = await prisma.post.delete({
-    where: { id: Number(postId) },
+    where: { id: postId },
   })
   res.json(post)
 }

--- a/javascript/rest-nextjs/pages/api/publish/[id].js
+++ b/javascript/rest-nextjs/pages/api/publish/[id].js
@@ -4,7 +4,7 @@ import prisma from '../../../lib/prisma'
 export default async function handle(req, res) {
   const postId = req.query.id
   const post = await prisma.post.update({
-    where: { id: Number(postId) },
+    where: { id: postId },
     data: { published: true },
   })
   res.json(post)

--- a/javascript/rest-nextjs/pages/p/[id].jsx
+++ b/javascript/rest-nextjs/pages/p/[id].jsx
@@ -63,8 +63,9 @@ const Post = props => {
 }
 
 export const getServerSideProps = async (context) => {
+  const id = Array.isArray(context.params.id) ? context.params.id[0] : context.params.id
   const post = await prisma.post.findUnique({
-    where: { id: Number(context.params.id) },
+    where: { id },
     include: { author: true },
   })
   return { props: { ...makeSerializable(post) } }

--- a/javascript/rest-nextjs/prisma/schema.prisma
+++ b/javascript/rest-nextjs/prisma/schema.prisma
@@ -3,19 +3,19 @@ generator client {
 }
 
 datasource db {
-  provider = "sqlite"
-  url      = "file:./dev.db"
+  provider = "cockroachdb"
+  url      = env("DATABASE_URL")
 }
 
 model User {
-  id    Int     @id @default(autoincrement())
+  id    String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   email String  @unique
   name  String?
   posts Post[]
 }
 
 model Post {
-  id        Int      @id @default(autoincrement())
+  id        String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   title     String
@@ -23,5 +23,5 @@ model Post {
   published Boolean  @default(false)
   viewCount Int      @default(0)
   author    User?    @relation(fields: [authorId], references: [id])
-  authorId  Int?
+  authorId  String?  @db.Uuid
 }


### PR DESCRIPTION
This included:

* updating the schema/code to use uuids instead of ints
* updating the database provider / url parameter for crdb and the
  environment variable DATABASE_URL
* added a vercel deploy button to the readme

Note, I'll update the base branch to be the cockroachdb/prisma-examples fork after our fork is up to date. 